### PR TITLE
[FIX] Fixed crash when launching server.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### 2.0.1 (2023-12-17)
+-   Fix crash when launching server.
+
+### 2.0.0 (2023-12-15)
+-   Second release of the mod.
+
 ### 1.5.0 (2023-12-15)
 -   Zhuangzi
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ mod_name=Butterfly Mod
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=All Rights Reserved
 # The mod version. See https://semver.org/
-mod_version=2.0.0
+mod_version=2.0.1
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/com/bokmcdok/butterflies/client/gui/screens/ButterflyBookScreen.java
+++ b/src/main/java/com/bokmcdok/butterflies/client/gui/screens/ButterflyBookScreen.java
@@ -32,6 +32,7 @@ import java.util.List;
  * The UI for the butterfly book, where players can look up information on
  * butterfly species.
  */
+@OnlyIn(Dist.CLIENT)
 public class ButterflyBookScreen extends Screen {
 
     // A cache for the page components.

--- a/src/main/java/com/bokmcdok/butterflies/client/renderer/entity/ButterflyRenderer.java
+++ b/src/main/java/com/bokmcdok/butterflies/client/renderer/entity/ButterflyRenderer.java
@@ -6,11 +6,14 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.renderer.entity.EntityRendererProvider;
 import net.minecraft.client.renderer.entity.MobRenderer;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * This is the renderer for all the butterflies in the game.
  */
+@OnlyIn(Dist.CLIENT)
 public class ButterflyRenderer  extends MobRenderer<Butterfly, ButterflyModel> {
     /**
      * Bakes a new model for the renderer

--- a/src/main/java/com/bokmcdok/butterflies/client/renderer/entity/ButterflyScrollRenderer.java
+++ b/src/main/java/com/bokmcdok/butterflies/client/renderer/entity/ButterflyScrollRenderer.java
@@ -11,11 +11,14 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.entity.EntityRenderer;
 import net.minecraft.client.renderer.entity.EntityRendererProvider;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Renders a butterfly scroll hanging off a surface.
  */
+@OnlyIn(Dist.CLIENT)
 public class ButterflyScrollRenderer extends EntityRenderer<ButterflyScroll> {
 
     /**

--- a/src/main/java/com/bokmcdok/butterflies/client/renderer/entity/CaterpillarRenderer.java
+++ b/src/main/java/com/bokmcdok/butterflies/client/renderer/entity/CaterpillarRenderer.java
@@ -9,11 +9,14 @@ import net.minecraft.client.renderer.entity.EntityRendererProvider;
 import net.minecraft.client.renderer.entity.MobRenderer;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * The renderer for the caterpillar entity.
  */
+@OnlyIn(Dist.CLIENT)
 public class CaterpillarRenderer
         extends MobRenderer<Caterpillar, CaterpillarModel> {
 

--- a/src/main/java/com/bokmcdok/butterflies/client/renderer/entity/ChrysalisRenderer.java
+++ b/src/main/java/com/bokmcdok/butterflies/client/renderer/entity/ChrysalisRenderer.java
@@ -9,8 +9,11 @@ import net.minecraft.client.renderer.entity.EntityRendererProvider;
 import net.minecraft.client.renderer.entity.MobRenderer;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 import org.jetbrains.annotations.NotNull;
 
+@OnlyIn(Dist.CLIENT)
 public class ChrysalisRenderer extends MobRenderer<Chrysalis, ChrysalisModel> {
 
     /**

--- a/src/main/java/com/bokmcdok/butterflies/client/texture/ButterflyTextures.java
+++ b/src/main/java/com/bokmcdok/butterflies/client/texture/ButterflyTextures.java
@@ -1,10 +1,13 @@
 package com.bokmcdok.butterflies.client.texture;
 
 import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 
 /**
  * Holds the textures used for butterfly scrolls.
  */
+@OnlyIn(Dist.CLIENT)
 public class ButterflyTextures {
 
     // The location of the book texture.

--- a/src/main/java/com/bokmcdok/butterflies/world/item/ButterflyBookItem.java
+++ b/src/main/java/com/bokmcdok/butterflies/world/item/ButterflyBookItem.java
@@ -13,6 +13,8 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 import org.jetbrains.annotations.NotNull;
 
 public class ButterflyBookItem extends Item {
@@ -69,10 +71,19 @@ public class ButterflyBookItem extends Item {
         ItemStack itemStack = player.getItemInHand(hand);
 
         if (level.isClientSide()) {
-            Minecraft.getInstance().setScreen(new ButterflyBookScreen(itemStack));
+            openScreen(itemStack);
         }
 
         player.awardStat(Stats.ITEM_USED.get(this));
         return InteractionResultHolder.sidedSuccess(itemStack, level.isClientSide());
+    }
+
+    /**
+     * Open the screen. Kept separate so it can be excluded from server builds.
+     * @param book The book to display.
+     */
+    @OnlyIn(Dist.CLIENT)
+    private void openScreen(ItemStack book) {
+        Minecraft.getInstance().setScreen(new ButterflyBookScreen(book));
     }
 }

--- a/src/main/java/com/bokmcdok/butterflies/world/item/ButterflyScrollItem.java
+++ b/src/main/java/com/bokmcdok/butterflies/world/item/ButterflyScrollItem.java
@@ -20,6 +20,8 @@ import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.gameevent.GameEvent;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -69,7 +71,7 @@ public class ButterflyScrollItem extends Item implements ButterflyContainerItem 
         if (level.isClientSide()) {
             CompoundTag tag = itemstack.getTag();
             if (tag != null && tag.contains(CompoundTagId.CUSTOM_MODEL_DATA)) {
-                Minecraft.getInstance().setScreen(new ButterflyScrollScreen(tag.getInt(CompoundTagId.CUSTOM_MODEL_DATA)));
+                openScreen(tag.getInt(CompoundTagId.CUSTOM_MODEL_DATA));
             } else {
                 replaceWithPaper(player, hand, itemstack);
             }
@@ -137,6 +139,15 @@ public class ButterflyScrollItem extends Item implements ButterflyContainerItem 
      */
     protected boolean mayPlace(Player player, Direction direction, ItemStack itemStack, BlockPos blockPos) {
         return !direction.getAxis().isVertical() && player.mayUseItemAt(blockPos, direction, itemStack);
+    }
+
+    /**
+     * Open the screen. Kept separate so it can be excluded from server builds.
+     * @param butterflyIndex The index of the butterfly.
+     */
+    @OnlyIn(Dist.CLIENT)
+    private void openScreen(int butterflyIndex) {
+        Minecraft.getInstance().setScreen(new ButterflyScrollScreen(butterflyIndex));
     }
 
     /**

--- a/src/main/java/com/bokmcdok/butterflies/world/item/ButterflyZhuangziItem.java
+++ b/src/main/java/com/bokmcdok/butterflies/world/item/ButterflyZhuangziItem.java
@@ -9,6 +9,8 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 import org.jetbrains.annotations.NotNull;
 
 public class ButterflyZhuangziItem extends Item {
@@ -37,10 +39,18 @@ public class ButterflyZhuangziItem extends Item {
         ItemStack itemstack = player.getItemInHand(hand);
 
         if (level.isClientSide()) {
-            Minecraft.getInstance().setScreen(new ButterflyZhuangziScreen());
+            openScreen();
         }
 
         player.awardStat(Stats.ITEM_USED.get(this));
         return InteractionResultHolder.sidedSuccess(itemstack, level.isClientSide());
+    }
+
+    /**
+     * Open the screen. Kept separate so it can be excluded from server builds.
+     */
+    @OnlyIn(Dist.CLIENT)
+    private void openScreen() {
+        Minecraft.getInstance().setScreen(new ButterflyZhuangziScreen());
     }
 }


### PR DESCRIPTION
This was down to `setScreen` being called directly from Item classes, causing the servers to look for GUI classes. Moving the call to a client-only method fixes it.