### PR TITLE
[FEATURE] New goal for moths that will draw them to flames.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## Changelog
 
+### 4.2.0 (2024-07-11)
+- Moths will now be drawn to brighter areas.
+
 ### 4.1.0 (2024-07-02)
 - Added diurnality to butterflies.
-- 
+
 ### 4.0.1 (2024-07-05)
 - Fixed bounding box for butterflies, so they won't escape bottles.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ mod_name=Butterfly Mod
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=All Rights Reserved
 # The mod version. See https://semver.org/
-mod_version=4.1.0
+mod_version=4.2.0
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/com/bokmcdok/butterflies/world/ButterflyData.java
+++ b/src/main/java/com/bokmcdok/butterflies/world/ButterflyData.java
@@ -103,6 +103,7 @@ public record ButterflyData(int butterflyIndex,
     
     public enum ButterflyType {
         BUTTERFLY,
+        MOTH,
         SPECIAL
     }
 

--- a/src/main/java/com/bokmcdok/butterflies/world/entity/ai/ButterflyLayEggGoal.java
+++ b/src/main/java/com/bokmcdok/butterflies/world/entity/ai/ButterflyLayEggGoal.java
@@ -68,6 +68,15 @@ public class ButterflyLayEggGoal extends MoveToBlockGoal {
     }
 
     /**
+     * Ensure the butterfly isn't in the landed state when the goal ends.
+     */
+    @Override
+    public void stop() {
+        this.butterfly.setLanded(false);
+        super.stop();
+    }
+
+    /**
      * Update the butterfly after it has landed.
      */
     @Override

--- a/src/main/java/com/bokmcdok/butterflies/world/entity/ai/ButterflyPollinateFlowerGoal.java
+++ b/src/main/java/com/bokmcdok/butterflies/world/entity/ai/ButterflyPollinateFlowerGoal.java
@@ -89,7 +89,6 @@ public class ButterflyPollinateFlowerGoal extends MoveToBlockGoal {
      */
     @Override
     public void start() {
-        this.butterfly.setLanded(false);
         attemptedToPollinate = false;
         super.start();
     }

--- a/src/main/java/com/bokmcdok/butterflies/world/entity/ai/ButterflyRestGoal.java
+++ b/src/main/java/com/bokmcdok/butterflies/world/entity/ai/ButterflyRestGoal.java
@@ -64,6 +64,15 @@ public class ButterflyRestGoal extends MoveToBlockGoal {
     }
 
     /**
+     * Ensure the butterfly isn't in the landed state when the goal ends.
+     */
+    @Override
+    public void stop() {
+        this.butterfly.setLanded(false);
+        super.stop();
+    }
+
+    /**
      * Update the butterfly after it has landed.
      */
     @Override

--- a/src/main/java/com/bokmcdok/butterflies/world/entity/ai/ButterflyWanderGoal.java
+++ b/src/main/java/com/bokmcdok/butterflies/world/entity/ai/ButterflyWanderGoal.java
@@ -1,76 +1,20 @@
 package com.bokmcdok.butterflies.world.entity.ai;
 
 import com.bokmcdok.butterflies.world.entity.animal.Butterfly;
-import net.minecraft.core.BlockPos;
-import net.minecraft.world.entity.ai.goal.Goal;
-import net.minecraft.world.level.pathfinder.Path;
-
-import java.util.EnumSet;
+import net.minecraft.world.entity.ai.goal.WaterAvoidingRandomFlyingGoal;
 
 /**
  * Wander goal to determine the position a butterfly will move to.
  */
-public class ButterflyWanderGoal extends Goal {
-    private final Butterfly butterfly;
+public class ButterflyWanderGoal extends WaterAvoidingRandomFlyingGoal {
 
     /**
      * Construction - set this to a movement goal.
      * @param butterfly The entity this goal belongs to.
+     * @param speedModifier The speed modifier to apply to this goal.
      */
-    public ButterflyWanderGoal(Butterfly butterfly) {
-        this.setFlags(EnumSet.of(Flag.MOVE, Flag.JUMP));
-        this.butterfly = butterfly;
-    }
-
-    /**
-     * Returns TRUE if we can keep using this goal.
-     * @return Whether we can continue to use the goal.
-     */
-    @Override
-    public boolean canContinueToUse() {
-        return this.butterfly.getNavigation().isInProgress();
-    }
-
-
-    /**
-     * Returns TRUE if we can use this goal.
-     * @return Whether we can use the goal.
-     */
-    @Override
-    public boolean canUse() {
-        return this.butterfly.getNavigation().isDone();
-    }
-
-    /**
-     * Start using the goal - sets a target for our navigation.
-     */
-    @Override
-    public void start() {
-        this.butterfly.setLanded(false);
-
-        //  Try to find a target.
-        BlockPos targetPosition = this.findPos();
-        if (targetPosition != null) {
-            Path path = this.butterfly.getNavigation().createPath(targetPosition, 1);
-            this.butterfly.getNavigation().moveTo(path, 1.0);
-        }
-    }
-
-    /**
-     * Gets a random position for our butterfly to fly to.
-     * @return A random position.
-     */
-    private BlockPos findPos() {
-        BlockPos position = butterfly.blockPosition();
-        BlockPos targetPosition =  position.offset(butterfly.getRandom().nextInt(8) - 4,
-                                                   butterfly.getRandom().nextInt(6) - 2,
-                                                   butterfly.getRandom().nextInt(8) - 4);
-
-        //  Make sure this is an air block.
-        if (butterfly.level().getBlockState(targetPosition).isAir()) {
-            return targetPosition;
-        }
-
-        return null;
+    public ButterflyWanderGoal(Butterfly butterfly, double speedModifier) {
+        super(butterfly, speedModifier);
+        this.setInterval(1);
     }
 }

--- a/src/main/java/com/bokmcdok/butterflies/world/entity/ai/MothWanderGoal.java
+++ b/src/main/java/com/bokmcdok/butterflies/world/entity/ai/MothWanderGoal.java
@@ -1,0 +1,39 @@
+package com.bokmcdok.butterflies.world.entity.ai;
+
+import com.bokmcdok.butterflies.world.entity.animal.Butterfly;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.Nullable;
+
+public class MothWanderGoal extends ButterflyWanderGoal {
+
+    /**
+     * Construction - set this to a movement goal.
+     * @param butterfly     The entity this goal belongs to.
+     * @param speedModifier The speed modifier to apply to this goal.
+     */
+    public MothWanderGoal(Butterfly butterfly, double speedModifier) {
+        super(butterfly, speedModifier);
+    }
+
+    /**
+     * Moths will tend toward brighter areas.
+     * @return The target position, if a valid position is found.
+     */
+    @Nullable
+    @Override
+    protected Vec3 getPosition() {
+        Vec3 pos = super.getPosition();
+
+        if (pos != null) {
+            int targetBrightness = this.mob.level().getRawBrightness(new BlockPos((int)pos.x(), (int)pos.y(), (int)pos.z()), 0);
+            int localBrightness = this.mob.level().getRawBrightness(this.mob.blockPosition(), 0);
+
+            if (targetBrightness < localBrightness) {
+                pos = super.getPosition();
+            }
+        }
+
+        return pos;
+    }
+}


### PR DESCRIPTION
Made butterfly construction smoother using on-access creation of the butterfly data reference. Modified goals so butterflies exit the landed state when a goal ends instead of relying on other goals to do this for them. Modified the wander goal so it now uses Minecraft's superior pathfinding code with an interval of `1` so they don't hover in place.

The new `MothWanderGoal` will cause moths to "reroll" their target position if the first one is darker. This will cause them to tend toward brighter positions, but won't prevent them from moving to darker block positions.