### PR TITLE
fix: prevent network deserialization crash during datapack sync

### DIFF
--- a/src/main/java/com/bokmcdok/butterflies/network/protocol/common/custom/ClientBoundButterflyDataPacket.java
+++ b/src/main/java/com/bokmcdok/butterflies/network/protocol/common/custom/ClientBoundButterflyDataPacket.java
@@ -48,6 +48,7 @@ public record ClientBoundButterflyDataPacket(Collection<ButterflyData> data) imp
             collectionBuffer.writeUtf(i.coldVariant());
             collectionBuffer.writeUtf(i.mateVariant());
             collectionBuffer.writeUtf(i.warmVariant());
+            collectionBuffer.writeUtf(i.agedVariant());
         });
     }
 


### PR DESCRIPTION
Fixed missing `agedVariant` string field serialization in `ClientBoundButterflyDataPacket.write()`, resolving network packet buffer corruption and client disconnections during server datapack synchronization.